### PR TITLE
Update anime-studio-ghibli.json List

### DIFF
--- a/data/achievement/anime-studio-ghibli.json
+++ b/data/achievement/anime-studio-ghibli.json
@@ -23,6 +23,7 @@
             "A431",   //Howl no Ugoku Shiro
             "A16664", //Kaguya-hime no Monogatari
             "A7711",  //Karigurashi no Arrietty
+            "A572",   //Kaze no Tani no Nausicaä
             "A16662", //Kaze Tachinu
             "A10029", //Kokurikozaka kara
             "A416",   //Kurenai no Buta


### PR DESCRIPTION
Kaze no Tani no Nausicaä (Nausicaä of the Valley of the Wind) Is missing from the list. 
Made by Studio Ghibli and Studio Hibari, same who worked on Majo no Takkyuubin (Kiki's Delivery Service) which is on the list.

- https://myanimelist.net/anime/572/Kaze_no_Tani_no_Nausica
- https://myanimelist.net/anime/512/Majo_no_Takkyuubin