### PR TITLE
Improve readability of the History tab

### DIFF
--- a/public/media/css/user/history.css
+++ b/public/media/css/user/history.css
@@ -40,7 +40,7 @@ ul.infobox {
 }
 .history-monthly table .box {
 	height: 2em;
-	background: #1969CB;
+	border: 1px solid #1969CB;
 }
 .history-monthly table .box-wrapper {
 	position: relative;

--- a/src/Views/user-history-monthly.phtml
+++ b/src/Views/user-history-monthly.phtml
@@ -35,7 +35,7 @@
 									<td class="<?php echo $class ?>">
 								<?php endif ?>
 									<div class="box-wrapper">
-										<div class="box" style="opacity: <?php printf('%.02f', count($entries) / max(1, $viewContext->monthlyHistoryMax)) ?>">
+										<div class="box" style="background-color: rgba(25, 105, 203, <?php printf('%.02f', count($entries) / max(1, $viewContext->monthlyHistoryMax)) ?>)">
 										</div>
 									</div>
 								</td>


### PR DESCRIPTION
The extremely pale color used for months of low activity in the History tab can be difficult to see. This PR will add a solid #1969cb border around each month's box and fade the inner background color according to the user's activity for that month.