### PR TITLE
tooltip text change from 'completing' to 'watching'

### DIFF
--- a/src/Views/user-recommendations-missing.phtml
+++ b/src/Views/user-recommendations-missing.phtml
@@ -25,7 +25,7 @@
 										<li>
 											<a target="_blank" href="<?php echo $entry->mal_link ?>" title="<?php echo htmlspecialchars($entry->title) ?>" rel="noreferrer">
                                                 <?php if ($entry->status == UserListStatus::Completing): ?>
-                                                    <i data-tooltip="Completing" class="left icon-status-completing"></i>
+                                                    <i data-tooltip="Watching" class="left icon-status-completing"></i>
                                                 <?php elseif ($entry->status == UserListStatus::Dropped): ?>
                                                     <i data-tooltip="Dropped" class="left icon-status-dropped"></i>
 												<?php elseif ($entry->status == UserListStatus::Planned): ?>


### PR DESCRIPTION
Change the tooltip text on the recomendations page from "completing" to "watching" as the icon only shows up next to entries that the user is currently watching.

Already completed entries have no icon.